### PR TITLE
Ensure last branch point is found for fully-ahead branches

### DIFF
--- a/conventional_commits/compile_release_notes.py
+++ b/conventional_commits/compile_release_notes.py
@@ -141,12 +141,23 @@ class ReleaseNoteCompiler:
         graph = self._get_git_branch_graph()
         graph_lines = graph.split("\n")
 
+        # There is no branch point if the git history is entirely linear.
         if all(line.startswith("*") for line in graph_lines):
             return None
 
+        # Look for the first branch point - this is the oldest commit in the first set of unbroken asterisk-preceded
+        # lines in the graph.
+        branch_point = None
+
         for line in graph_lines:
+            # Find the oldest commit in the first set of unbroken asterisk-preceded lines in the graph.
             if line.startswith("*"):
-                return line.split()[1]
+                branch_point = line.split()[1]
+            else:
+                if branch_point is not None:
+                    return branch_point
+
+        return None
 
     def _get_git_branch_graph(self):
         """Get the one-line git log branch graph.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = conventional_commits
-version = 0.1.1
+version = 0.1.2
 description = A pre-commit hook, semantic version checker, and release note compiler for facilitating continuous deployment via Conventional Commits.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/test_compile_release_notes.py
+++ b/tests/test_compile_release_notes.py
@@ -109,9 +109,9 @@ class TestReleaseNoteCompiler(unittest.TestCase):
 
         self.assertEqual(release_notes, expected)
 
-    def test_get_last_branch_point_with_left_most_branch(self):
+    def test_get_last_branch_point_with_fully_ahead_branch(self):
         """Test that the `ReleaseNoteCompiler._get_last_branch_point` method selects the correct commit hash from the
-        git log branch graph when the current branch is displayed as the left-most branch.
+        git log branch graph when the current branch is fully-ahead (i.e. ahead of all other branches).
         """
         mock_git_log_graph = "\n".join(
             [
@@ -134,9 +134,9 @@ class TestReleaseNoteCompiler(unittest.TestCase):
         with patch(self.GET_GIT_BRANCH_GRAPH_METHOD_PATH, return_value=mock_git_log_graph):
             self.assertEqual(ReleaseNoteCompiler(stop_point="LAST_BRANCH_POINT")._get_last_branch_point(), "85f6612")
 
-    def test_get_last_branch_point_with_non_left_most_branch(self):
+    def test_get_last_branch_point_with_non_fully_ahead_branch(self):
         """Test that the `ReleaseNoteCompiler._get_last_branch_point` method selects the correct commit hash from the
-        git log branch graph when the current branch is displayed as the non-left-most branch.
+        git log branch graph when the current branch is not fully-ahead (i.e. not ahead of all other branches).
         """
         mock_git_log_graph = "\n".join(
             [

--- a/tests/test_compile_release_notes.py
+++ b/tests/test_compile_release_notes.py
@@ -109,9 +109,34 @@ class TestReleaseNoteCompiler(unittest.TestCase):
 
         self.assertEqual(release_notes, expected)
 
-    def test_get_last_branch_point(self):
+    def test_get_last_branch_point_with_left_most_branch(self):
         """Test that the `ReleaseNoteCompiler._get_last_branch_point` method selects the correct commit hash from the
-        git log branch graph.
+        git log branch graph when the current branch is displayed as the left-most branch.
+        """
+        mock_git_log_graph = "\n".join(
+            [
+                "* 4e358b9 ENH: Improve error message for missing commit body"
+                "* 4dc189a ENH: Give more information in commit header line length violation",
+                "* e64332b ENH: Pretty print allowed commit codes in commit message checker",
+                "*   85f6612 (tag: 0.1.0, origin/main, main) MRG: Merge pull request #21",
+                '|"',
+                "| * b1148e2 (fix/only-use-extra-commits-on-branch-for-release-note) OPS: Update release note workflow",
+                "| * 9c62f4e FIX: Return None if no branch point is found by ReleaseNoteCompiler",
+                "| * ec6dd01 OPS: Fix mkver.conf",
+                "| * ff4b837 FEA: Add LAST_BRANCH_POINT stop point for ReleaseNoteCompiler",
+                "|/",
+                "*   3e7dc54 (tag: 0.0.13) MRG: Merge pull request #20 from octue/refactor/compile-regex-once",
+                '|"',
+                "| * fabd2ab FIX: Ignore commit messages that are only merges of commit refs",
+            ]
+        )
+
+        with patch(self.GET_GIT_BRANCH_GRAPH_METHOD_PATH, return_value=mock_git_log_graph):
+            self.assertEqual(ReleaseNoteCompiler(stop_point="LAST_BRANCH_POINT")._get_last_branch_point(), "85f6612")
+
+    def test_get_last_branch_point_with_non_left_most_branch(self):
+        """Test that the `ReleaseNoteCompiler._get_last_branch_point` method selects the correct commit hash from the
+        git log branch graph when the current branch is displayed as the non-left-most branch.
         """
         mock_git_log_graph = "\n".join(
             [


### PR DESCRIPTION
<!--- SKIP AUTOGENERATED NOTES --->
## Contents

### Fixes
- [x] Ensure last branch point is found for fully-ahead branches (where a "fully-ahead" branch is ahead of all other branches)

<!--- END AUTOGENERATED NOTES --->