### PR TITLE
Allow use of non-default version file location in semantic version checker

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
           - '^release/(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'
 
   - repo: https://github.com/octue/conventional-commits
-    rev: 0.0.4
+    rev: 0.1.2
     hooks:
       - id: check-commit-message-is-conventional
         stages: [commit-msg]

--- a/conventional_commits/check_semantic_version.py
+++ b/conventional_commits/check_semantic_version.py
@@ -1,3 +1,5 @@
+import argparse
+import os
 import subprocess
 import sys
 
@@ -14,20 +16,31 @@ VERSION_PARAMETERS = {
 }
 
 
-def get_current_version(version_source, package_name=None):
+def get_current_version(version_source, package_name=None, version_source_file=None):
     """Get the current version of the package via the given version source. If getting the version via `npm` from a
     `package.json` file, the name of the package is required.
 
     :param str version_source: the name of the method to use to acquire the current version number (one of "setup.py", "poetry", or "npm")
     :param str|None package_name: the name of the package if it is needed for getting the version (e.g. for npm)
+    :param str|None version_source_file: the path to the version source file if it is not in the current working directory
     :return str:
     """
+    original_directory = os.path.abspath(os.getcwd())
     version_parameters = VERSION_PARAMETERS[version_source]
 
     if package_name:
         version_parameters[0] = version_parameters[0].format(package_name)
 
-    process = subprocess.run(version_parameters[0], shell=version_parameters[1], capture_output=True)
+    if version_source_file:
+        file_directory = os.path.abspath(os.path.dirname(version_source_file))
+        os.chdir(file_directory)
+
+    try:
+        process = subprocess.run(version_parameters[0], shell=version_parameters[1], capture_output=True)
+    finally:
+        if version_source_file:
+            os.chdir(original_directory)
+
     return process.stdout.strip().decode("utf8")
 
 
@@ -40,18 +53,23 @@ def get_expected_semantic_version():
     return process.stdout.strip().decode("utf8")
 
 
-def main():
+def main(argv=None):
     """Compare the current version to the expected semantic version. If they match, exit successfully with an exit code
     of 0; if they don't, exit with an exit code of 1.
 
     :return None:
     """
-    if len(sys.argv) >= 3:
-        package_name = sys.argv[2]
-    else:
-        package_name = None
+    parser = argparse.ArgumentParser()
+    parser.add_argument("version_source")
+    parser.add_argument("--package-name", default=None)
+    parser.add_argument("--file", default=None)
 
-    current_version = get_current_version(version_source=sys.argv[1], package_name=package_name)
+    args = parser.parse_args(argv)
+
+    current_version = get_current_version(
+        version_source=args.version_source, package_name=args.package_name, version_source_file=args.file
+    )
+
     expected_semantic_version = get_expected_semantic_version()
 
     if current_version == "null":

--- a/conventional_commits/check_semantic_version.py
+++ b/conventional_commits/check_semantic_version.py
@@ -54,6 +54,10 @@ def main():
     current_version = get_current_version(version_source=sys.argv[1], package_name=package_name)
     expected_semantic_version = get_expected_semantic_version()
 
+    if current_version == "null":
+        print(f"{RED}VERSION FAILED CHECKS:{NO_COLOUR} No current version found.")
+        sys.exit(1)
+
     if current_version != expected_semantic_version:
         print(
             f"{RED}VERSION FAILED CHECKS:{NO_COLOUR} The current version ({current_version}) is different from the "

--- a/conventional_commits/check_semantic_version.py
+++ b/conventional_commits/check_semantic_version.py
@@ -72,7 +72,7 @@ def main(argv=None):
 
     expected_semantic_version = get_expected_semantic_version()
 
-    if current_version == "null":
+    if not current_version or current_version == "null":
         print(f"{RED}VERSION FAILED CHECKS:{NO_COLOUR} No current version found.")
         sys.exit(1)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = conventional_commits
-version = 0.1.3
+version = 0.2.0
 description = A pre-commit hook, semantic version checker, and release note compiler for facilitating continuous deployment via Conventional Commits.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = conventional_commits
-version = 0.1.2
+version = 0.1.3
 description = A pre-commit hook, semantic version checker, and release note compiler for facilitating continuous deployment via Conventional Commits.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/test_check_semantic_version.py
+++ b/tests/test_check_semantic_version.py
@@ -32,66 +32,55 @@ class TestCheckSemanticVersion(unittest.TestCase):
         """Test that the correct message and error message are returned if the current version and the expected version
         are the same.
         """
-        with patch("sys.argv", return_value=["test_check_semantic_version", "setup.py"]):
-            with patch(
-                "conventional_commits.check_semantic_version.get_expected_semantic_version", return_value="0.3.9"
-            ):
-                with patch("conventional_commits.check_semantic_version.get_current_version", return_value="0.3.9"):
-                    with patch("sys.stdout") as mock_stdout:
-                        with self.assertRaises(SystemExit) as e:
-                            check_semantic_version.main()
+        with patch("conventional_commits.check_semantic_version.get_expected_semantic_version", return_value="0.3.9"):
+            with patch("conventional_commits.check_semantic_version.get_current_version", return_value="0.3.9"):
+                with patch("sys.stdout") as mock_stdout:
+                    with self.assertRaises(SystemExit) as e:
+                        check_semantic_version.main(["setup.py"])
 
-                            # Check that the exit code is 0.
-                            self.assertFalse(hasattr(e, "exception"))
+                        # Check that the exit code is 0.
+                        self.assertFalse(hasattr(e, "exception"))
 
-                        message = mock_stdout.method_calls[0].args[0]
-                        self.assertIn("VERSION PASSED CHECKS:", message)
-                        self.assertIn(
-                            "The current version is the same as the expected semantic version: 0.3.9.", message
-                        )
+                    message = mock_stdout.method_calls[0].args[0]
+                    self.assertIn("VERSION PASSED CHECKS:", message)
+                    self.assertIn("The current version is the same as the expected semantic version: 0.3.9.", message)
 
     def test_main_with_non_matching_versions(self):
         """Test that the correct message and error message are returned if the current version and the expected version
         are not the same.
         """
-        with patch("sys.argv", return_value=["test_check_semantic_version", "setup.py"]):
-            with patch(
-                "conventional_commits.check_semantic_version.get_expected_semantic_version", return_value="0.5.3"
-            ):
-                with patch("conventional_commits.check_semantic_version.get_current_version", return_value="0.3.9"):
-                    with patch("sys.stdout") as mock_stdout:
-                        with self.assertRaises(SystemExit) as e:
-                            check_semantic_version.main()
+        with patch("conventional_commits.check_semantic_version.get_expected_semantic_version", return_value="0.5.3"):
+            with patch("conventional_commits.check_semantic_version.get_current_version", return_value="0.3.9"):
+                with patch("sys.stdout") as mock_stdout:
+                    with self.assertRaises(SystemExit) as e:
+                        check_semantic_version.main(["setup.py"])
 
-                            # Check that the exit code is 1.
-                            self.assertEqual(e.exception.code, 1)
+                        # Check that the exit code is 1.
+                        self.assertEqual(e.exception.code, 1)
 
-                        message = mock_stdout.method_calls[0].args[0]
-                        self.assertIn("VERSION FAILED CHECKS:", message)
-                        self.assertIn(
-                            "The current version (0.3.9) is different from the expected semantic version (0.5.3).",
-                            message,
-                        )
+                    message = mock_stdout.method_calls[0].args[0]
+                    self.assertIn("VERSION FAILED CHECKS:", message)
+                    self.assertIn(
+                        "The current version (0.3.9) is different from the expected semantic version (0.5.3).",
+                        message,
+                    )
 
     def test_main_with_non_matching_versions_reversed(self):
         """Test that the correct message and error message are returned if the current version and the expected version
         are not the same (reversed compared to the previous test).
         """
-        with patch("sys.argv", return_value=["test_check_semantic_version", "setup.py"]):
-            with patch(
-                "conventional_commits.check_semantic_version.get_expected_semantic_version", return_value="0.3.9"
-            ):
-                with patch("conventional_commits.check_semantic_version.get_current_version", return_value="0.5.3"):
-                    with patch("sys.stdout") as mock_stdout:
-                        with self.assertRaises(SystemExit) as e:
-                            check_semantic_version.main()
+        with patch("conventional_commits.check_semantic_version.get_expected_semantic_version", return_value="0.3.9"):
+            with patch("conventional_commits.check_semantic_version.get_current_version", return_value="0.5.3"):
+                with patch("sys.stdout") as mock_stdout:
+                    with self.assertRaises(SystemExit) as e:
+                        check_semantic_version.main(["setup.py"])
 
-                            # Check that the exit code is 1.
-                            self.assertEqual(e.exception.code, 1)
+                        # Check that the exit code is 1.
+                        self.assertEqual(e.exception.code, 1)
 
-                        message = mock_stdout.method_calls[0].args[0]
-                        self.assertIn("VERSION FAILED CHECKS:", message)
-                        self.assertIn(
-                            "The current version (0.5.3) is different from the expected semantic version (0.3.9).",
-                            message,
-                        )
+                    message = mock_stdout.method_calls[0].args[0]
+                    self.assertIn("VERSION FAILED CHECKS:", message)
+                    self.assertIn(
+                        "The current version (0.5.3) is different from the expected semantic version (0.3.9).",
+                        message,
+                    )


### PR DESCRIPTION
<!--- SKIP AUTOGENERATED NOTES --->
## Contents

### New features
- [x] Enable different version source file location in semantic version checker

### Enhancements
- [x] Raise more helpful error if no current version found

### Fixes
- [x] Fix `npm` version parameters command string

### Operations
- [x] Use new conventional commit checker in this repo