### PR TITLE
Use base branch to determine branch point

### DIFF
--- a/conventional_commits/compile_release_notes.py
+++ b/conventional_commits/compile_release_notes.py
@@ -137,6 +137,10 @@ class ReleaseNoteCompiler:
         return requests.get(pull_request_url, headers=headers).json()
 
     def _get_git_remote_name(self):
+        """Get the name of the git remote (usually "origin").
+
+        :return str:
+        """
         return subprocess.run(["git", "remote"], capture_output=True).stdout.strip().decode()
 
     def _get_git_log(self):

--- a/conventional_commits/compile_release_notes.py
+++ b/conventional_commits/compile_release_notes.py
@@ -79,7 +79,7 @@ class ReleaseNoteCompiler:
 
         if self.stop_point == LAST_BRANCH_POINT:
             if self.current_pull_request is not None:
-                self.base_branch = self._get_git_remote_name() + "/" + self.current_pull_request["base"]["ref"]
+                self.base_branch = self.current_pull_request["base"]["ref"]
             else:
                 self.stop_point = LAST_RELEASE
 
@@ -123,11 +123,11 @@ class ReleaseNoteCompiler:
         ).strip('"\n')
 
     def _get_current_pull_request(self, pull_request_url, api_token):
-        """Get the current pull request description (body) from the GitHub API.
+        """Get the current pull request from the GitHub API.
 
         :param str pull_request_url: the GitHub API URL for the pull request
         :param str|None api_token: GitHub API token
-        :return str:
+        :return dict:
         """
         if api_token is None:
             headers = {}
@@ -135,13 +135,6 @@ class ReleaseNoteCompiler:
             headers = {"Authorization": f"token {api_token}"}
 
         return requests.get(pull_request_url, headers=headers).json()
-
-    def _get_git_remote_name(self):
-        """Get the name of the git remote (usually "origin").
-
-        :return str:
-        """
-        return subprocess.run(["git", "remote"], capture_output=True).stdout.strip().decode()
 
     def _get_git_log(self):
         """Get the one-line decorated git log formatted with "|" delimiting the commit hash, message, and decoration.

--- a/conventional_commits/compile_release_notes.py
+++ b/conventional_commits/compile_release_notes.py
@@ -194,11 +194,11 @@ class ReleaseNoteCompiler:
             if self.base_branch in decoration:
                 return True
 
-        if self.stop_point == LAST_RELEASE:
+        elif self.stop_point == LAST_RELEASE:
             if "tag" in decoration:
                 return bool(SEMANTIC_VERSION_PATTERN.search(decoration))
 
-        if self.stop_point == LAST_PULL_REQUEST:
+        elif self.stop_point == LAST_PULL_REQUEST:
             return PULL_REQUEST_INDICATOR in message
 
     def _categorise_commit_messages(self, parsed_commits, unparsed_commits):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = conventional_commits
-version = 0.2.2
+version = 0.2.3
 description = A pre-commit hook, semantic version checker, and release note compiler for facilitating continuous deployment via Conventional Commits.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/test_compile_release_notes.py
+++ b/tests/test_compile_release_notes.py
@@ -34,7 +34,6 @@ class TestReleaseNoteCompiler(unittest.TestCase):
     GET_CURRENT_PULL_REQUEST_PATH = (
         "conventional_commits.compile_release_notes.ReleaseNoteCompiler._get_current_pull_request"
     )
-    GET_GIT_REMOTE_NAME_PATH = "conventional_commits.compile_release_notes.ReleaseNoteCompiler._get_git_remote_name"
     MOCK_PULL_REQUEST_URL = "https://api.github.com/repos/blah/my-repo/pulls/11"
 
     def test_unsupported_stop_point_results_in_error(self):
@@ -112,7 +111,7 @@ class TestReleaseNoteCompiler(unittest.TestCase):
                 "358ffd5|REF: Move stop point checking into separate method|",
                 "44927c6|FIX: Fix LAST_PULL_REQUEST stop point bug|",
                 "7cdc980|FIX: Ensure uncategorised commits are not lost| (fix/allow-extra-colons-in-commit-message)",
-                "741bb8d|OPS: Increase version to 0.0.11|  (tag: 0.0.11, origin/my-base-branch)",
+                "741bb8d|OPS: Increase version to 0.0.11|  (tag: 0.0.11, my-base-branch)",
                 "27092a4|FIX: Allow extra colons in commit headers in release notes compiler|",
                 "6dcdc41|MRG: Merge pull request #17 from octue/fix/fix-release-notes-stop-point-bug| (tag: 0.0.10)",
             ]
@@ -122,10 +121,9 @@ class TestReleaseNoteCompiler(unittest.TestCase):
             with patch(
                 self.GET_CURRENT_PULL_REQUEST_PATH, return_value={"body": "", "base": {"ref": "my-base-branch"}}
             ):
-                with patch(self.GET_GIT_REMOTE_NAME_PATH, return_value="origin"):
-                    release_notes = ReleaseNoteCompiler(
-                        stop_point="LAST_BRANCH_POINT", pull_request_url=self.MOCK_PULL_REQUEST_URL
-                    ).compile_release_notes()
+                release_notes = ReleaseNoteCompiler(
+                    stop_point="LAST_BRANCH_POINT", pull_request_url=self.MOCK_PULL_REQUEST_URL
+                ).compile_release_notes()
 
         expected = "\n".join(
             [


### PR DESCRIPTION
## Summary
Use the base branch from the pull request JSON to determine the branch point rather than a naive algorithm based on the git log graph.

## Contents

<!--- SKIP AUTOGENERATED NOTES --->
### Fixes
- [x] Use the base branch from the pull request JSON to determine branch point

### Refactoring
- [x] Avoid unnecessary conditional evaluations