### PR TITLE
Add links to commit diffs in release notes compiler

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = conventional_commits
-version = 0.4.0
+version = 0.5.0
 description = A pre-commit hook, semantic version checker, and release note compiler for facilitating continuous deployment via Conventional Commits.
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
## Summary

<!--- START AUTOGENERATED NOTES --->
## Contents ([#45](https://github.com/octue/conventional-commits/pull/45))

### Operations
- Increase version

<!--- END AUTOGENERATED NOTES --->


## Quality Checklist

- [ ] New features are fully tested (No matter how much Coverage Karma you have)
- [ ] **[v0.2 onward]** New features are included in the documentation
- [ ] **[v0.2 onward]** Breaking changes are documented with clear instructions of what 

### Coverage Karma

- [ ] If your PR decreases test coverage, do you feel you have built enough `Coverage Karma`* to justify it?

*Coverage Karma can be earned by disproportionally increasing test coverage in the rest of your contributions.
It's an honesty policy - you keep count of your own.