### PR TITLE
Improve release notes compiler error handling if pull request not found

### DIFF
--- a/conventional_commits/__init__.py
+++ b/conventional_commits/__init__.py
@@ -1,0 +1,12 @@
+import logging
+
+
+formatter = logging.Formatter("[" + " | ".join(("%(asctime)s", "%(levelname)s", "%(name)s")) + "]" + " %(message)s")
+
+handler = logging.StreamHandler()
+handler.setFormatter(formatter)
+handler.setLevel(logging.INFO)
+
+logger = logging.getLogger()
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)

--- a/conventional_commits/compile_release_notes.py
+++ b/conventional_commits/compile_release_notes.py
@@ -1,4 +1,5 @@
 import argparse
+import logging
 import re
 import subprocess
 
@@ -7,6 +8,9 @@ import requests
 from conventional_commits.check_commit_message import (
     BREAKING_CHANGE_INDICATORS as CONVENTIONAL_COMMIT_BREAKING_CHANGE_INDICATORS,
 )
+
+
+logger = logging.getLogger(__name__)
 
 
 LAST_RELEASE = "LAST_RELEASE"
@@ -75,12 +79,14 @@ class ReleaseNotesCompiler:
 
         self.stop_point = stop_point.upper()
 
+        self.current_pull_request = None
+        self.previous_notes = None
+
         if pull_request_url:
             self.current_pull_request = self._get_current_pull_request(pull_request_url, api_token)
-            self.previous_notes = self.current_pull_request["body"]
-        else:
-            self.current_pull_request = None
-            self.previous_notes = None
+
+            if self.current_pull_request:
+                self.previous_notes = self.current_pull_request["body"]
 
         self.header = header
         self.list_item_symbol = list_item_symbol
@@ -92,6 +98,8 @@ class ReleaseNotesCompiler:
                 self.base_branch = self.current_pull_request["base"]["ref"]
             else:
                 self.stop_point = LAST_RELEASE
+
+        logger.info(f"Using {self.stop_point!r} stop point.")
 
     def compile_release_notes(self):
         """Compile the commit messages since the given stop point into a new set of release notes, sorting them into
@@ -142,7 +150,17 @@ class ReleaseNotesCompiler:
         else:
             headers = {"Authorization": f"token {api_token}"}
 
-        return requests.get(pull_request_url, headers=headers).json()
+        response = requests.get(pull_request_url, headers=headers)
+
+        if response.status_code == 200:
+            return response.json()
+
+        try:
+            response.raise_for_status()
+        except requests.HTTPError:
+            logger.warning(
+                f"Pull request could not be found; resorting to using {LAST_RELEASE} stop point.\n", exc_info=True
+            )
 
     def _get_git_log(self):
         """Get the one-line decorated git log formatted in the pattern of "hash|§header|§body|§decoration@@@".

--- a/conventional_commits/compile_release_notes.py
+++ b/conventional_commits/compile_release_notes.py
@@ -155,12 +155,10 @@ class ReleaseNotesCompiler:
         if response.status_code == 200:
             return response.json()
 
-        try:
-            response.raise_for_status()
-        except requests.HTTPError:
-            logger.warning(
-                f"Pull request could not be found; resorting to using {LAST_RELEASE} stop point.\n", exc_info=True
-            )
+        logger.warning(
+            f"Pull request could not be accessed; resorting to using {LAST_RELEASE} stop point.\n"
+            f"{response.status_code}: {response.text}."
+        )
 
     def _get_git_log(self):
         """Get the one-line decorated git log formatted in the pattern of "hash|§header|§body|§decoration@@@".

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = conventional_commits
-version = 0.4.0
+version = 0.4.1
 description = A pre-commit hook, semantic version checker, and release note compiler for facilitating continuous deployment via Conventional Commits.
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
## Summary

<!--- SKIP AUTOGENERATED NOTES --->
## Contents ([#49](https://github.com/octue/conventional-commits/pull/49))

### Enhancements
- Add package-level logging
- Raise error if pull request isn't found or is not accessible

<!--- END AUTOGENERATED NOTES --->