### PR TITLE
Add whitespace to valid commit header endings

### DIFF
--- a/conventional_commits/check_commit_message.py
+++ b/conventional_commits/check_commit_message.py
@@ -65,7 +65,7 @@ class ConventionalCommitMessageChecker:
         self,
         allowed_commit_codes=None,
         maximum_header_length=72,
-        valid_header_ending_pattern=r"[A-Za-z\d\"\']",
+        valid_header_ending_pattern=r"[A-Za-z\d\"\'\s]",
         require_body=False,
         maximum_body_line_length=72,
     ):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = conventional_commits
-version = 0.5.2
+version = 0.5.3
 description = A pre-commit hook, semantic version checker, and release note compiler for facilitating continuous deployment via Conventional Commits.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/test_check_commit_message.py
+++ b/tests/test_check_commit_message.py
@@ -39,14 +39,16 @@ class TestCheckCommitMessage(unittest.TestCase):
         with self.assertRaises(ValueError):
             ConventionalCommitMessageChecker().check_commit_message(["FIX: Fix this bug."])
 
+    def test_valid_header_endings(self):
+        """Test that a commit message with a valid header ending is ok."""
+        for ending in ("'", " ", "blah", "32"):
+            with self.subTest(ending=ending):
+                ConventionalCommitMessageChecker().check_commit_message(['REV: Reverts "FIX: Fix a bug"'])
+
     def test_non_blank_header_separator_line_raises_error(self):
         """Test that a commit message with a non-blank header separator line results in an error."""
         with self.assertRaises(ValueError):
             ConventionalCommitMessageChecker().check_commit_message(["FIX: Fix this bug", "Body started too early."])
-
-    def test_valid_header_ending(self):
-        """Test that a commit message with a valid header ending is ok."""
-        ConventionalCommitMessageChecker().check_commit_message(['REV: Reverts "FIX: Fix a bug"'])
 
     def test_with_body_when_body_not_required(self):
         """Test that a commit message with a valid header and body when a body is not required is ok."""


### PR DESCRIPTION
<!--- START AUTOGENERATED NOTES --->
## Contents ([#55](https://github.com/octue/conventional-commits/pull/55))

### Enhancements
- Add whitespace to valid commit header endings

<!--- END AUTOGENERATED NOTES --->