### PR TITLE
Fix and improve commit message checker

### DIFF
--- a/conventional_commits/check_commit_message.py
+++ b/conventional_commits/check_commit_message.py
@@ -182,18 +182,13 @@ class ConventionalCommitMessageChecker:
         :raise ValueError: if the breaking change indicator is invalid
         :return None:
         """
-        breaking_change_error = ValueError(
-            f"Breaking changes must be denoted by one of {BREAKING_CHANGE_INDICATORS!r} in uppercase followed by ': ' "
-            f"and a description e.g. 'BREAKING CHANGE: Change MyPublicClass interface'; received "
-            f"{line!r}."
-        )
-
-        if any(indicator.lower() in line for indicator in BREAKING_CHANGE_INDICATORS):
-            raise breaking_change_error
-
-        if any(indicator in line for indicator in BREAKING_CHANGE_INDICATORS):
+        if any(line.strip().lower().startswith(indicator.lower()) for indicator in BREAKING_CHANGE_INDICATORS):
             if not re.match(BREAKING_CHANGE_PATTERN, line):
-                raise breaking_change_error
+                raise ValueError(
+                    f"Breaking changes must be denoted by one of {BREAKING_CHANGE_INDICATORS!r} in uppercase followed "
+                    f"by ': ' and a description e.g. 'BREAKING CHANGE: Change MyPublicClass interface'; received "
+                    f"{line!r}."
+                )
 
 
 def main(argv=None):

--- a/conventional_commits/check_commit_message.py
+++ b/conventional_commits/check_commit_message.py
@@ -65,7 +65,7 @@ class ConventionalCommitMessageChecker:
         self,
         allowed_commit_codes=None,
         maximum_header_length=72,
-        valid_header_ending_pattern=r"[A-Za-z\d\"\'\s]",
+        valid_header_ending_pattern=r"[A-Za-z\d\"\'\s)`]",
         require_body=False,
         maximum_body_line_length=72,
     ):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = conventional_commits
-version = 0.5.3
+version = 0.5.4
 description = A pre-commit hook, semantic version checker, and release note compiler for facilitating continuous deployment via Conventional Commits.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/test_check_commit_message.py
+++ b/tests/test_check_commit_message.py
@@ -137,6 +137,14 @@ class TestCheckCommitMessage(unittest.TestCase):
         ConventionalCommitMessageChecker().check_commit_message(["FIX: Fix this bug", "", "BREAKING CHANGE: blah"])
         ConventionalCommitMessageChecker().check_commit_message(["FIX: Fix this bug", "", "BREAKING-CHANGE: blah"])
 
+    def test_breaking_change_section_can_contain_the_words_breaking_change_after_breaking_change_indicators(self):
+        """Test that the breaking change section can contain the words 'breaking change' after the breaking change
+        indicator.
+        """
+        ConventionalCommitMessageChecker()._validate_breaking_change_descriptions(
+            "BREAKING-CHANGE: Uncategorised commits contain breaking changes including the use of..."
+        )
+
 
 class TestMain(unittest.TestCase):
     def test_with_invalid_commit_message(self):

--- a/tests/test_check_commit_message.py
+++ b/tests/test_check_commit_message.py
@@ -41,9 +41,9 @@ class TestCheckCommitMessage(unittest.TestCase):
 
     def test_valid_header_endings(self):
         """Test that a commit message with a valid header ending is ok."""
-        for ending in ("'", " ", "blah", "32"):
+        for ending in ("'", " ", '"' "blah", "32", ")", "`"):
             with self.subTest(ending=ending):
-                ConventionalCommitMessageChecker().check_commit_message(['REV: Reverts "FIX: Fix a bug"'])
+                ConventionalCommitMessageChecker().check_commit_message(["REV: Reverts FIX: Fix a bug" + ending])
 
     def test_non_blank_header_separator_line_raises_error(self):
         """Test that a commit message with a non-blank header separator line results in an error."""


### PR DESCRIPTION
<!--- START AUTOGENERATED NOTES --->
## Contents ([#63](https://github.com/octue/conventional-commits/pull/63))

### Enhancements
- Allow backticks and brackets at end of commit message

### Fixes
- Allow breaking change section to contain the words breaking change

<!--- END AUTOGENERATED NOTES --->