### PR TITLE
Allow long lines in commit message body by default

### DIFF
--- a/conventional_commits/check_commit_message.py
+++ b/conventional_commits/check_commit_message.py
@@ -67,7 +67,7 @@ class ConventionalCommitMessageChecker:
         maximum_header_length=72,
         valid_header_ending_pattern=r"[A-Za-z\d\"\'\s)`]",
         require_body=False,
-        maximum_body_line_length=72,
+        maximum_body_line_length=10000,
     ):
         self.allowed_commit_codes = allowed_commit_codes or ALLOWED_COMMIT_CODES
         self.maximum_header_length = maximum_header_length

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = conventional_commits
-version = 0.6.3
+version = 0.6.4
 description = A pre-commit hook, semantic version checker, and release note compiler for facilitating continuous deployment via Conventional Commits.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/test_check_commit_message.py
+++ b/tests/test_check_commit_message.py
@@ -67,15 +67,15 @@ class TestCheckCommitMessage(unittest.TestCase):
 
     def test_body_lines_over_maximum_length_raises_error(self):
         """Test that a commit message with a body that has a line that is too long results in an error."""
-        with self.assertRaises(ValueError):
-            ConventionalCommitMessageChecker(require_body=True).check_commit_message(
-                ["FIX: Fix this bug", "", f"{'a' * 80}"]
-            )
+        commit_message_checker = ConventionalCommitMessageChecker(require_body=True, maximum_body_line_length=72)
 
-        with self.assertRaises(ValueError):
-            ConventionalCommitMessageChecker(require_body=True).check_commit_message(
-                ["FIX: Fix this bug", "", "an okay line", f"{'a' * 80}"]
-            )
+        for commits in (
+            ["FIX: Fix this bug", "", f"{'a' * 80}"],
+            ["FIX: Fix this bug", "", "an okay line", f"{'a' * 80}"],
+        ):
+            with self.subTest(commits=commits):
+                with self.assertRaises(ValueError):
+                    commit_message_checker.check_commit_message(commits)
 
     def test_comments_lines_are_ignored(self):
         """Test that comment lines in the commit message are ignored."""

--- a/tests/test_check_commit_message.py
+++ b/tests/test_check_commit_message.py
@@ -69,13 +69,13 @@ class TestCheckCommitMessage(unittest.TestCase):
         """Test that a commit message with a body that has a line that is too long results in an error."""
         commit_message_checker = ConventionalCommitMessageChecker(require_body=True, maximum_body_line_length=72)
 
-        for commits in (
+        for commit_message_lines in (
             ["FIX: Fix this bug", "", f"{'a' * 80}"],
             ["FIX: Fix this bug", "", "an okay line", f"{'a' * 80}"],
         ):
-            with self.subTest(commits=commits):
+            with self.subTest(commit_message_lines=commit_message_lines):
                 with self.assertRaises(ValueError):
-                    commit_message_checker.check_commit_message(commits)
+                    commit_message_checker.check_commit_message(commit_message_lines)
 
     def test_comments_lines_are_ignored(self):
         """Test that comment lines in the commit message are ignored."""


### PR DESCRIPTION
# Summary
Allow long lines in commit message bodies by default to allow easier markdown editing in breaking change sections of commit messages.

<!--- SKIP AUTOGENERATED NOTES --->
# Contents ([#75](https://github.com/octue/conventional-commits/pull/75))

### Fixes
- Increase default maximum commit body length to 10000

<!--- END AUTOGENERATED NOTES --->